### PR TITLE
Use cross sbt version when publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - stage: test
       script: sbt test
     - stage: publish
-      script: sbt publish
+      script: sbt ^publish
 
 stages:
   - name: test # runs on master commits and PRs


### PR DESCRIPTION
So we can use latest (`1.2.4`) sbt version when developing, and first version that guarantees binary compatibility across series (`1.0.0`) for publishing.