### PR TITLE
For javadoc, link to class instead of object

### DIFF
--- a/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
@@ -69,8 +69,8 @@ class ApidocDirective(allClasses: IndexedSeq[String]) extends InlineDirective("a
   }
 
   def renderByClassName(label: String, node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
-    val query       = node.label.replaceAll("\\\\_", "_")
-    val className   = baseClassName(query)
+    val query            = node.label.replaceAll("\\\\_", "_")
+    val className        = baseClassName(query)
     val scalaClassSuffix = if (query.endsWith("$")) "$" else ""
 
     val matches = allClasses.filter(_.endsWith('.' + className))

--- a/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
@@ -71,7 +71,7 @@ class ApidocDirective(allClasses: IndexedSeq[String]) extends InlineDirective("a
   def renderByClassName(label: String, node: DirectiveNode, visitor: Visitor, printer: Printer): Unit = {
     val query       = node.label.replaceAll("\\\\_", "_")
     val className   = baseClassName(query)
-    val classSuffix = if (query.endsWith("$")) "$" else ""
+    val scalaClassSuffix = if (query.endsWith("$")) "$" else ""
 
     val matches = allClasses.filter(_.endsWith('.' + className))
     matches.size match {
@@ -80,14 +80,14 @@ class ApidocDirective(allClasses: IndexedSeq[String]) extends InlineDirective("a
       case 1 if matches(0).contains("adsl") =>
         throw new java.lang.IllegalStateException(s"Match for $query only found in one language: ${matches(0)}")
       case 1 =>
-        syntheticNode("scala", scalaLabel(query), matches(0) + classSuffix, node).accept(visitor)
-        syntheticNode("java", javaLabel(query), matches(0) + classSuffix, node).accept(visitor)
+        syntheticNode("scala", scalaLabel(query), matches(0) + scalaClassSuffix, node).accept(visitor)
+        syntheticNode("java", javaLabel(query), matches(0), node).accept(visitor)
       case 2 if matches.forall(_.contains("adsl")) =>
         matches.foreach(m => {
           if (!m.contains("javadsl"))
-            syntheticNode("scala", scalaLabel(query), m + classSuffix, node).accept(visitor)
+            syntheticNode("scala", scalaLabel(query), m + scalaClassSuffix, node).accept(visitor)
           if (!m.contains("scaladsl"))
-            syntheticNode("java", javaLabel(query), m + classSuffix, node).accept(visitor)
+            syntheticNode("java", javaLabel(query), m, node).accept(visitor)
         })
       case n =>
         throw new java.lang.IllegalStateException(

--- a/src/test/scala/com.lightbend.paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com.lightbend.paradox/apidoc/ApidocDirectiveSpec.scala
@@ -18,7 +18,7 @@ package com.lightbend.paradox.apidoc
 
 import com.lightbend.paradox.markdown.Writer
 
-class ApidocPluginSpec extends MarkdownBaseSpec {
+class ApidocDirectiveSpec extends MarkdownBaseSpec {
   val rootPackage = "akka"
 
   val allClasses = Array(

--- a/src/test/scala/com.lightbend.paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com.lightbend.paradox/apidoc/ApidocDirectiveSpec.scala
@@ -113,7 +113,7 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
       html(
         """<p><span class="group-scala">
           |<a href="https://doc.akka.io/api/akka/2.5/akka/cluster/client/ClusterClient$.html">ClusterClient</a></span><span class="group-java">
-          |<a href="https://doc.akka.io/japi/akka/2.5/?akka/cluster/client/ClusterClient$.html">ClusterClient</a></span>
+          |<a href="https://doc.akka.io/japi/akka/2.5/?akka/cluster/client/ClusterClient.html">ClusterClient</a></span>
           |</p>""".stripMargin
       )
   }


### PR DESCRIPTION
Since for each object a class with static forwarders is generated, which is
the thing a Java user would probably use.