### PR TITLE
Look for classes in LocalRoot project aggregate by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ jobs:
       name: Build code style check (fixed with `sbt scalafmtSbt`)
     - stage: test
       script: sbt test
-      name: Tests run
+      name: Run tests
+    - script: sbt scripted
+      name: Run sbt plugin tests
     - stage: publish
       script: sbt ^publish
       name: Publish artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
-scalaVersion := "2.12.8"
+import scala.collection.JavaConverters._
+
+scalaVersion := "2.12.9"
 
 sbtPlugin        := true
 crossSbtVersions := List("1.0.0")
@@ -31,3 +33,9 @@ bintrayRepository   := "sbt-plugin-releases"
 
 enablePlugins(AutomateHeaderPlugin)
 scalafmtOnCompile := true
+
+enablePlugins(SbtPlugin)
+scriptedLaunchOpts += ("-Dproject.version=" + version.value)
+scriptedLaunchOpts ++= java.lang.management.ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.filter(
+  a => Seq("-Xmx", "-Xms", "-XX", "-Dfile").exists(a.startsWith)
+)

--- a/src/main/scala/com/lightbend/paradox/apidoc/ApidocKeys.scala
+++ b/src/main/scala/com/lightbend/paradox/apidoc/ApidocKeys.scala
@@ -19,5 +19,7 @@ package com.lightbend.paradox.apidoc
 import sbt._
 
 trait ApidocKeys {
-  val apidocRootPackage = settingKey[String]("")
+  val apidocRootPackage = settingKey[String]("Root package for all candidate classes")
+  val apidocProjects    = settingKey[Seq[ProjectReference]]("Projects which will be queried for classes to link to")
+  val apidocClasses     = taskKey[Seq[URL]]("All of the classes that will be queried")
 }

--- a/src/sbt-test/apidoc/multi-project/build.sbt
+++ b/src/sbt-test/apidoc/multi-project/build.sbt
@@ -1,0 +1,17 @@
+val lib = project
+
+val docs = project
+  .enablePlugins(ParadoxPlugin)
+  .settings(
+    paradoxTheme := None,
+    paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
+    paradoxProperties ++= Map(
+      "scaladoc.apidoc.base_url" -> "https://localhost:8000",
+      "javadoc.apidoc.base_url" -> "https://localhost:8000"
+    ),
+    apidocRootPackage := ""
+  )
+
+val root = project
+  .in(file("."))
+  .aggregate(lib)

--- a/src/sbt-test/apidoc/multi-project/docs/src/main/paradox/_template/page.st
+++ b/src/sbt-test/apidoc/multi-project/docs/src/main/paradox/_template/page.st
@@ -1,0 +1,1 @@
+$page.content$

--- a/src/sbt-test/apidoc/multi-project/docs/src/main/paradox/index.md
+++ b/src/sbt-test/apidoc/multi-project/docs/src/main/paradox/index.md
@@ -1,0 +1,1 @@
+Api link to sub-project @apidoc[LibClass]

--- a/src/sbt-test/apidoc/multi-project/expected/index.html
+++ b/src/sbt-test/apidoc/multi-project/expected/index.html
@@ -1,0 +1,1 @@
+<p>Api link to sub-project <span class="group-scala"><a href="https://localhost:8000/apidoc/LibClass.html">LibClass</a></span><span class="group-java"><a href="https://localhost:8000/?apidoc/LibClass.html">LibClass</a></span></p>

--- a/src/sbt-test/apidoc/multi-project/lib/src/main/scala/LibClass.scala
+++ b/src/sbt-test/apidoc/multi-project/lib/src/main/scala/LibClass.scala
@@ -1,0 +1,3 @@
+package apidoc
+
+class LibClass

--- a/src/sbt-test/apidoc/multi-project/project/plugins.sbt
+++ b/src/sbt-test/apidoc/multi-project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % sys.props("project.version"))

--- a/src/sbt-test/apidoc/multi-project/test
+++ b/src/sbt-test/apidoc/multi-project/test
@@ -1,0 +1,3 @@
+> docs/paradox
+
+$ must-mirror docs/target/paradox/site/main/index.html expected/index.html

--- a/src/sbt-test/apidoc/single-project/build.sbt
+++ b/src/sbt-test/apidoc/single-project/build.sbt
@@ -1,0 +1,11 @@
+libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.25"
+
+enablePlugins(ParadoxPlugin)
+paradoxTheme := None
+paradoxGroups := Map("Language" -> Seq("Java", "Scala"))
+paradoxProperties ++= Map(
+  "scaladoc.akka.base_url" -> "https://doc.akka.io/api/akka/2.5",
+  "javadoc.akka.base_url" -> "https://doc.akka.io/japi/akka/2.5"
+)
+
+apidocRootPackage := "akka"

--- a/src/sbt-test/apidoc/single-project/expected/index.html
+++ b/src/sbt-test/apidoc/single-project/expected/index.html
@@ -1,0 +1,1 @@
+<p>Api link to Akka <span class="group-java"><a href="https://doc.akka.io/japi/akka/2.5/?akka/stream/javadsl/Flow.html">Flow</a></span><span class="group-scala"><a href="https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Flow.html">Flow</a></span></p>

--- a/src/sbt-test/apidoc/single-project/project/plugins.sbt
+++ b/src/sbt-test/apidoc/single-project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % sys.props("project.version"))

--- a/src/sbt-test/apidoc/single-project/src/main/paradox/_template/page.st
+++ b/src/sbt-test/apidoc/single-project/src/main/paradox/_template/page.st
@@ -1,0 +1,1 @@
+$page.content$

--- a/src/sbt-test/apidoc/single-project/src/main/paradox/index.md
+++ b/src/sbt-test/apidoc/single-project/src/main/paradox/index.md
@@ -1,0 +1,1 @@
+Api link to Akka @apidoc[Flow]

--- a/src/sbt-test/apidoc/single-project/test
+++ b/src/sbt-test/apidoc/single-project/test
@@ -1,0 +1,3 @@
+> paradox
+
+$ must-mirror target/paradox/site/main/index.html expected/index.html


### PR DESCRIPTION
This PR allows to select projects where linked classes will be searched in. This adds support for projects, where docs sub-project does not depend on the projects, where linked classes are.