### PR TITLE
Find and render inner classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ produce an unambigious result, you will have to use the FQCN.
     * Scala: Flow - `akka/stream/scaladsl/Flow.html`
     * Java: Flow -  `akka/stream/javadsl/Flow.html`
 
+* `@apidoc[Receptionist.Command]` (An inner class.)
+    * classes: `akka.actor.typed.receptionist.Receptionist$Command`
+    * Scala: Receptionist.Command - `akka/actor/typed/receptionist/Receptionist$$Command.html`
+    * Java: Receptionist.Command - `akka/actor/typed/receptionist/Receptionist.Command.html`
+
 * `@apidoc[Marshaller]` (The scaladoc/javadoc split can be on different package depth.)
     * classes: `akka.http.scaladsl.marshalling.Marshaller`, `akka.http.javadsl.marshalling.Marshaller`
     * Scala: Marshaller - `akka/http/scaladsl/marshalling/Marshaller.html`
@@ -58,7 +63,7 @@ produce an unambigious result, you will have to use the FQCN.
     * Scala: ClusterClient - `akka/cluster/client/ClusterClient$.html`
     * Java: ClusterClient - `akka/cluster/client/ClusterClient.html`
 
-* `@apidoc[Source[ServerSentEvent, \_]]` (Show type paramters.)
+* `@apidoc[Source[ServerSentEvent, \_]]` (Show type parameters.)
     * classes: `akka.stream.scaladsl.Source` - `akka.stream.javadsl.Source`
     * Scala: Source\[ServerSentEvent, _\] - `akka/stream/scaladsl/Source.html`
     * Java: Source\<ServerSentEvent, ?\> - `akka/stream/javadsl/Source.html`

--- a/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
@@ -37,9 +37,8 @@ class ApidocDirective(allClassesAndObjects: IndexedSeq[String], ctx: Writer.Cont
         case Some(la) => la + generics
       }
 
-    def scalaFqcn(matched: String): String = {
+    def scalaFqcn(matched: String): String =
       matched.replace("$", ".")
-    }
 
     def javaLabel(matched: String): String =
       scalaLabel(matched)
@@ -155,22 +154,36 @@ class ApidocDirective(allClassesAndObjects: IndexedSeq[String], ctx: Writer.Cont
         )
       case 1 =>
         val pkg = matches(0)
-        syntheticNode("scala", "scala", query.scalaLabel(pkg), query.scalaFqcn(pkg) + scalaClassSuffix, sAnchor, node).accept(visitor)
+        syntheticNode("scala", "scala", query.scalaLabel(pkg), query.scalaFqcn(pkg) + scalaClassSuffix, sAnchor, node)
+          .accept(visitor)
         if (hasJavadocUrl(pkg)) {
           syntheticNode("java", "java", query.javaLabel(pkg), query.javaFqcn(pkg), jAnchor, node).accept(visitor)
         } else
-          syntheticNode("java", "scala", query.javaLabel(pkg), query.scalaFqcn(pkg) + scalaClassSuffix, jAnchor, node).accept(visitor)
+          syntheticNode("java", "scala", query.javaLabel(pkg), query.scalaFqcn(pkg) + scalaClassSuffix, jAnchor, node)
+            .accept(visitor)
       case 2 if matches.forall(_.contains("adsl")) =>
         matches.foreach(pkg => {
           if (!pkg.contains("javadsl"))
-            syntheticNode("scala", "scala", query.scalaLabel(pkg), query.scalaFqcn(pkg) + scalaClassSuffix, sAnchor, node)
-              .accept(visitor)
+            syntheticNode(
+              "scala",
+              "scala",
+              query.scalaLabel(pkg),
+              query.scalaFqcn(pkg) + scalaClassSuffix,
+              sAnchor,
+              node
+            ).accept(visitor)
           if (!pkg.contains("scaladsl")) {
             if (hasJavadocUrl(pkg))
               syntheticNode("java", "java", query.javaLabel(pkg), query.javaFqcn(pkg), jAnchor, node).accept(visitor)
             else
-              syntheticNode("java", "scala", query.javaLabel(pkg), query.scalaFqcn(pkg) + scalaClassSuffix, jAnchor, node)
-                .accept(visitor)
+              syntheticNode(
+                "java",
+                "scala",
+                query.javaLabel(pkg),
+                query.scalaFqcn(pkg) + scalaClassSuffix,
+                jAnchor,
+                node
+              ).accept(visitor)
           }
         })
       case n =>

--- a/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
@@ -94,7 +94,7 @@ class ApidocDirective(allClassesAndObjects: IndexedSeq[String], ctx: Writer.Cont
             val regex = convertToRegex(classNameWithDollarForInnerClasses)
             allClasses.filter(cls => regex.findFirstMatchIn(cls).isDefined) match {
               case Seq() =>
-                ctx.error(s"Class not found for @apidoc[$query]", node)
+                ctx.error(s"Class not found for @apidoc[$query] (pattern $regex)", node)
               case results =>
                 renderMatches(query, results, node, visitor, printer)
             }
@@ -111,7 +111,7 @@ class ApidocDirective(allClassesAndObjects: IndexedSeq[String], ctx: Writer.Cont
     (classNameWithDollarForInnerClasses
       .replaceAll("\\.", "\\\\.")
       .replaceAll("\\*", ".*")
-      .replace("$", s"\\$$") + "$").r
+      .replaceAll("\\$", "\\\\\\$") + "$").r
 
   private def scaladocNode(
       group: String,

--- a/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
+++ b/src/main/scala/com/lightbend/paradox/apidoc/ApidocDirective.scala
@@ -107,12 +107,11 @@ class ApidocDirective(allClassesAndObjects: IndexedSeq[String], ctx: Writer.Cont
     }
   }
 
-  private def convertToRegex(classNameWithDollarForInnerClasses: String): Regex = {
+  private def convertToRegex(classNameWithDollarForInnerClasses: String): Regex =
     (classNameWithDollarForInnerClasses
       .replaceAll("\\.", "\\\\.")
       .replaceAll("\\*", ".*")
       .replace("$", s"\\$$") + "$").r
-  }
 
   private def scaladocNode(
       group: String,

--- a/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
@@ -121,7 +121,7 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
   it should "throw an exception when two matches found but javadsl/scaladsl is not in their packages" in {
     val thrown = the[ParadoxException] thrownBy markdown("@apidoc[ActorRef]")
     thrown.getMessage shouldEqual
-      "2 matches found for ActorRef, but not javadsl/scaladsl: akka.actor.ActorRef, akka.actor.typed.ActorRef. You may want to use the fully qualified class name as @apidoc[fqcn] instead of @apidoc[ActorRef]."
+      "2 matches found for ActorRef, but not javadsl/scaladsl: akka.actor.ActorRef, akka.actor.typed.ActorRef. You may want to use the fully qualified class name as @apidoc[fqcn] instead of @apidoc[ActorRef]. For examples see https://github.com/lightbend/sbt-paradox-apidoc#examples"
   }
 
   it should "generate markdown correctly when fully qualified class name (fqcn) is specified as @apidoc[fqcn]" in {
@@ -210,6 +210,26 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
         """<p><span class="group-scala">
           |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/scaladsl/Consumer$$Control.html" title="akka.kafka.scaladsl.Consumer.Control"><code>Consumer.Control[T]</code></a></span><span class="group-java">
           |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/javadsl/Consumer$$Control.html" title="akka.kafka.javadsl.Consumer.Control"><code>Consumer.Control&lt;T&gt;</code></a></span>
+          |</p>""".stripMargin
+      )
+  }
+
+  it should "be linked with a regex" in {
+    markdown("@apidoc[akka.kafka.(scaladsl|javadsl).Consumer.Control]") shouldEqual
+      html(
+        """<p><span class="group-scala">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/scaladsl/Consumer$$Control.html" title="akka.kafka.scaladsl.Consumer.Control"><code>Consumer.Control</code></a></span><span class="group-java">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/javadsl/Consumer$$Control.html" title="akka.kafka.javadsl.Consumer.Control"><code>Consumer.Control</code></a></span>
+          |</p>""".stripMargin
+      )
+  }
+
+  it should "be linked with a regex and label" in {
+    markdown("@apidoc[Consumer.Control](akka.kafka.(scaladsl|javadsl).Consumer.Control)") shouldEqual
+      html(
+        """<p><span class="group-scala">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/scaladsl/Consumer$$Control.html" title="akka.kafka.scaladsl.Consumer.Control"><code>Consumer.Control</code></a></span><span class="group-java">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/javadsl/Consumer$$Control.html" title="akka.kafka.javadsl.Consumer.Control"><code>Consumer.Control</code></a></span>
           |</p>""".stripMargin
       )
   }

--- a/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
@@ -46,7 +46,10 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
     "akka.stream.javadsl.Flow",
     "akka.stream.javadsl.Flow$",
     "akka.stream.scaladsl.Flow",
-    "akka.stream.scaladsl.Flow$"
+    "akka.stream.scaladsl.Flow$",
+    "akka.kafka.scaladsl.Consumer$Control",
+    "akka.kafka.javadsl.Consumer$Control",
+    "akka.actor.typed.receptionist.Receptionist$Command"
   )
 
   override val markdownWriter = new Writer(
@@ -64,7 +67,9 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
     "scaladoc.akka.base_url" -> "https://doc.akka.io/api/akka/2.5",
     "scaladoc.akka.http.base_url" -> "https://doc.akka.io/api/akka-http/current",
     "javadoc.akka.base_url" -> "https://doc.akka.io/japi/akka/2.5",
-    "javadoc.akka.http.base_url" -> "https://doc.akka.io/japi/akka-http/current"
+    "javadoc.akka.http.base_url" -> "https://doc.akka.io/japi/akka-http/current",
+    "scaladoc.akka.kafka.base_url" -> "https://doc.akka.io/api/alpakka-kafka/current",
+    "javadoc.akka.kafka.base_url" -> ""
   )
 
   "Apidoc directive" should "generate markdown correctly when there is only one match" in {
@@ -188,6 +193,38 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
           |thingie</p>""".stripMargin
       )
   }
+
+  "Inner classes" should "be linked (only scaladoc)" in {
+    markdown("@apidoc[Consumer.Control]") shouldEqual
+      html(
+        """<p><span class="group-scala">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/scaladsl/Consumer$$Control.html" title="akka.kafka.scaladsl.Consumer.Control"><code>Consumer.Control</code></a></span><span class="group-java">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/javadsl/Consumer$$Control.html" title="akka.kafka.javadsl.Consumer.Control"><code>Consumer.Control</code></a></span>
+          |</p>""".stripMargin
+      )
+  }
+
+  it should "be linked with a label and generics (only scaladoc)" in {
+    markdown("@apidoc[Consumer.Control[T]](Consumer.Control)") shouldEqual
+      html(
+        """<p><span class="group-scala">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/scaladsl/Consumer$$Control.html" title="akka.kafka.scaladsl.Consumer.Control"><code>Consumer.Control[T]</code></a></span><span class="group-java">
+          |<a href="https://doc.akka.io/api/alpakka-kafka/current/akka/kafka/javadsl/Consumer$$Control.html" title="akka.kafka.javadsl.Consumer.Control"><code>Consumer.Control&lt;T&gt;</code></a></span>
+          |</p>""".stripMargin
+      )
+  }
+
+  it should "generate links to inner classes" in {
+    markdown("@apidoc[Receptionist.Command]") shouldEqual
+      html(
+        """<p><span class="group-scala">
+          |<a href="https://doc.akka.io/api/akka/2.5/akka/actor/typed/receptionist/Receptionist$$Command.html" title="akka.actor.typed.receptionist.Receptionist.Command"><code>Receptionist.Command</code></a></span><span class="group-java">
+          |<a href="https://doc.akka.io/japi/akka/2.5/?akka/actor/typed/receptionist/Receptionist.Command.html" title="akka.actor.typed.receptionist.Receptionist.Command"><code>Receptionist.Command</code></a></span>
+          |</p>""".stripMargin
+      )
+  }
+
+
 
   "Directive with label and source" should "use the source as class pattern" in {
     markdown("The @apidoc[TheClass.method](Flow) { .scaladoc a=1 } thingie") shouldEqual

--- a/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
@@ -224,8 +224,6 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
       )
   }
 
-
-
   "Directive with label and source" should "use the source as class pattern" in {
     markdown("The @apidoc[TheClass.method](Flow) { .scaladoc a=1 } thingie") shouldEqual
       html(


### PR DESCRIPTION
Make `@apidoc` find even inner Scala classes with the same assumption as https://github.com/lightbend/paradox/pull/395 and https://github.com/lightbend/paradox/pull/397 make that class names start with a capital letter.

Fixes #86 
