### PR TITLE
Support link to methods with bounded types

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ produce an unambigious result, you will have to use the FQCN.
     * Scala: method - `akka/stream/scaladsl/Flow.html#method():Unit`
     * Java: method - `akka/stream/javadsl/Flow.html#method()`
 
+* `@apidoc[method](Flow) { scala="#method[T]():Unit" java="#method()" }` (Link to method anchors.)
+    * classes: `akka.stream.scaladsl.Flow` - `akka.stream.javadsl.Flow`
+    * Scala: method - `akka/stream/scaladsl/Flow.html#method[T]():Unit`
+    * Java: method - `akka/stream/javadsl/Flow.html#method()`
+
+* `@apidoc[method](Flow) { scala="#method%5BT%3C:S]():Unit" java="#method()" }` (Link to method anchors. Where the method has type bounds.)
+    * classes: `akka.stream.scaladsl.Flow` - `akka.stream.javadsl.Flow`
+    * Scala: method - `akka/stream/scaladsl/Flow.html#method[T<:S]():Unit`
+    * Java: method - `akka/stream/javadsl/Flow.html#method()`
+
+* `@apidoc[method](Flow) { scala="#method(String=%3EInt):Unit" java="#method()" }` (Link to method anchors. Using higher-order function arguments)
+    * classes: `akka.stream.scaladsl.Flow` - `akka.stream.javadsl.Flow`
+    * Scala: method - `akka/stream/scaladsl/Flow.html#method(String=>Int):Unit`
+    * Java: method - `akka/stream/javadsl/Flow.html#method()`
+
 
 ### When only Scaladoc is generated
 

--- a/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
@@ -286,12 +286,12 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
   }
   it should "use anchors for methods with scala bounded types" in {
     markdown(
-      """The @apidoc[label](Flow) { scala="#method[T%3C:Q[T]]](Flow=%3CUnit):Unit"  java="#method()" } thingie"""
+      """The @apidoc[label](Flow) { scala="#method%5BT%3C:Q[T]]](Flow=%3EUnit):Unit"  java="#method()" } thingie"""
     ) shouldEqual
       html(
         """<p>The <span class="group-java">
           |<a href="https://doc.akka.io/japi/akka/2.5/?akka/stream/javadsl/Flow.html#method()" title="akka.stream.javadsl.Flow"><code>label</code></a></span><span class="group-scala">
-          |<a href="https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Flow.html#method[T<:Q[T]]](Flow=%3EUnit):Unit" title="akka.stream.scaladsl.Flow"><code>label</code></a></span>
+          |<a href="https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Flow.html#method[T%3C:Q[T]]](Flow=%3EUnit):Unit" title="akka.stream.scaladsl.Flow"><code>label</code></a></span>
           |thingie</p>""".stripMargin
       )
   }

--- a/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
@@ -16,6 +16,8 @@
 
 package com.lightbend.paradox.apidoc
 
+import java.io.IOException
+
 import com.lightbend.paradox.ParadoxException
 import com.lightbend.paradox.markdown.Writer
 
@@ -284,15 +286,31 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
           |thingie</p>""".stripMargin
       )
   }
+
   it should "use anchors for methods with scala bounded types" in {
     markdown(
-      """The @apidoc[label](Flow) { scala="#method%5BT%3C:Q[T]]](Flow=%3EUnit):Unit"  java="#method()" } thingie"""
+      """The @apidoc[label](Flow) { scala="#method%5BT%3C:Q[T]](Flow=%3EUnit):Unit"  java="#method()" } thingie"""
     ) shouldEqual
       html(
         """<p>The <span class="group-java">
           |<a href="https://doc.akka.io/japi/akka/2.5/?akka/stream/javadsl/Flow.html#method()" title="akka.stream.javadsl.Flow"><code>label</code></a></span><span class="group-scala">
-          |<a href="https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Flow.html#method[T%3C:Q[T]]](Flow=%3EUnit):Unit" title="akka.stream.scaladsl.Flow"><code>label</code></a></span>
+          |<a href="https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Flow.html#method[T%3C:Q[T]](Flow=%3EUnit):Unit" title="akka.stream.scaladsl.Flow"><code>label</code></a></span>
           |thingie</p>""".stripMargin
       )
   }
+
+  it should "catch exception on malformed URIs and make suggestions" in {
+    try {
+
+      markdown(
+        """The @apidoc[label](Flow) { scala="#method[ T <: Q[T] ](Flow => Unit):Unit"  java="#method()" } thingie"""
+      )
+    } catch {
+      case t @ ParadoxException(error) => {
+        error.msg should include("template resulted in an invalid URL")
+        error.msg should include("method%5B T %3C: Q%5BT] ](Flow =%3E Unit):Unit")
+      }
+    }
+  }
+
 }

--- a/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
+++ b/src/test/scala/com/lightbend/paradox/apidoc/ApidocDirectiveSpec.scala
@@ -284,4 +284,15 @@ class ApidocDirectiveSpec extends MarkdownBaseSpec {
           |thingie</p>""".stripMargin
       )
   }
+  it should "use anchors for methods with scala bounded types" in {
+    markdown(
+      """The @apidoc[label](Flow) { scala="#method[T%3C:Q[T]]](Flow=%3CUnit):Unit"  java="#method()" } thingie"""
+    ) shouldEqual
+      html(
+        """<p>The <span class="group-java">
+          |<a href="https://doc.akka.io/japi/akka/2.5/?akka/stream/javadsl/Flow.html#method()" title="akka.stream.javadsl.Flow"><code>label</code></a></span><span class="group-scala">
+          |<a href="https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Flow.html#method[T<:Q[T]]](Flow=%3EUnit):Unit" title="akka.stream.scaladsl.Flow"><code>label</code></a></span>
+          |thingie</p>""".stripMargin
+      )
+  }
 }


### PR DESCRIPTION
Trying to link to `{ scala="#method[T<:Q[T]]]():Unit" }` fails with: `template resulted in an invalid URL [akka.stream.scaladsl.Flow#method[T<:Q[T]]]():Unit]` because of `<` but replacing `<` with `%3C` generates the wrong link because `%` is escaped to `%25`.

This was a bit surprising because it is possible to code `=>` in a method signature using `=%3E` and in that case `%` is respected resulting in a valid URL.

