### PR TITLE
Upgrade dependencies to move away from repo.scala-sbt.org

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Library {
   val classgraph     = "io.github.classgraph"   % "classgraph"  % "4.8.162"
-  val sbtParadox     = "com.lightbend.paradox"  % "sbt-paradox" % "0.10.5"
+  val sbtParadox     = "com.lightbend.paradox"  % "sbt-paradox" % "0.10.6"
   val scalatest      = "org.scalatest"         %% "scalatest"   % "3.2.14"
-  val paradoxTestkit = "com.lightbend.paradox" %% "testkit"     % "0.10.5"
+  val paradoxTestkit = "com.lightbend.paradox" %% "testkit"     % "0.10.6"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.10.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")
 addSbtPlugin("com.github.sbt"    % "sbt-github-actions" % "0.16.0")
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.11")
+addSbtPlugin("com.github.sbt"    % "sbt-ci-release"     % "1.5.12")


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`. 

* sbt-paradox 0.10.5 still hosted on repo.scala-sbt.org, migrated to maven central with latest 0.10.6
* sbt-ci-release 1.5.11 pull in older sbt-dynver release still hosted on repo.scala-sbt.org, latest version fixed that.

Replaces
- #247

@johanandren After merging this (and maybe some other PRs from scala-steward) can you cut a 1.0.1 release? Thanks!